### PR TITLE
close #27

### DIFF
--- a/blog-mode.el
+++ b/blog-mode.el
@@ -469,13 +469,16 @@
 
 (defadvice save-buffer (around blog-save-buffer)
   "編集した、あるいは新規に作成したファイル名を Export-list.txt に記録する"
-  (if (string= "blog" (format "%s" mode-name))
-      (if (string= "t" (buffer-modified-p (current-buffer)))
+  (if (string= "t" (format "%s" (buffer-modified-p)))
+      (if (string= "blog" (format "%s" mode-name))
           (progn
             (blog-modified-record (format "~/org/blog/%s" (buffer-name (current-buffer))))
             ad-do-it)
         ad-do-it)
-    ad-do-it))
+    (if (string= "blog" (format "%s" mode-name))
+        ad-do-it
+      ad-do-it
+      (message "(No changes need to be saved)"))))
 (ad-activate 'save-buffer)
 
 (defun blog-end ()


### PR DESCRIPTION
# 変更点
- バッファ内容が変更されているかいないか、さらに現在 blog-mode であるかそうでないか、によって行われる処理を分けた。

- 以下のように save-buffer に代わる新たな関数を定義することも考えたが、blog-mode にて誤って blog-back-page (C-c C-left) ではなく save-buffer (C-x C-s) を行ってしまった場合に、Export-list.txt へのファイル名の書き込みが行われなくなることになってしまうため、この方法はやめておいた。
``` emacs-lisp
(defun blog-save-buffer ()
  "編集した、あるいは新規に作成したファイルであれば Export-list.txt に記録する、blog-mode 用の save-buffer"
  (if (string= "t" (format "%s" (buffer-modified-p)))
      (blog-modified-record (format "~/org/blog/%s" (buffer-name (current-buffer))))
    nil)
  (save-buffer))
```